### PR TITLE
Add test scenarios

### DIFF
--- a/test_scenarios/UC3_Abort CT.md
+++ b/test_scenarios/UC3_Abort CT.md
@@ -6,5 +6,11 @@ __App User__ wybrał opcję "Abort" na uruchomionym CT
 
 ### Główny
 
-##### 1. System wyświetla informację o poprawnym anulowaniu CT.
+##### 1. System wyświetla okno potriwerdzenia, z pytaniem "Are you sure?".
 ##### 2. __App User__ wybiera opcję "OK"
+##### 3. System wyświetla informację o poprawnym anulowaniu CT.
+##### 4. __App User__ wybiera opcję "OK"
+
+### 2a. __App User__ wybiera opcję "Cancel"
+
+##### 2a1. System przechodzi do widoku CT.

--- a/test_scenarios/UC3_Abort CT.md
+++ b/test_scenarios/UC3_Abort CT.md
@@ -1,0 +1,10 @@
+# Test scenario
+
+## UC3 Abort CT
+
+__App User__ wybrał opcję "Abort" na uruchomionym CT
+
+### Główny
+
+##### 1. System wyświetla informację o poprawnym anulowaniu CT.
+##### 2. __App User__ wybiera opcję "OK"

--- a/test_scenarios/UC4_Activate Computation Task.md
+++ b/test_scenarios/UC4_Activate Computation Task.md
@@ -7,14 +7,20 @@
 ##### 1. __App User__ wybiera opcję wyświetlenia zdefiniowanych CT
 ##### 2. System wyświetla listę zdefiniowanych CT
 ##### 3. __App User__ wybiera opcję "Activate" przy zdefiniowanym CT
-##### 4. System wyświetla informację o poprawnym uruchomieniu CT
+##### 4. System wyśietla dane wejściowe CT.
 ##### 5. __App User__ wybiera opcję "OK"
+##### 6. System wyświetla informację o poprawnym uruchomieniu CT
+##### 7. __App User__ wybiera opcję "OK"
  
-### 4a. CT miał niepoprawnie zdefiniowany logger.
+### 5a. __App USer__ wybiera opcję "Cancel"
 
-##### 4a1. System wyświetla otrzeżenie o niemożliwości skomunikowania się z loggerem.
+##### 5a1. System przechodzi do widoku CT.
+ 
+### 6a. CT miał niepoprawnie zdefiniowany logger.
+
+##### 6a1. System wyświetla otrzeżenie o niemożliwości skomunikowania się z loggerem.
 ##### GOTO 5
 
-### 5a. App User wybiera opcję "Abort"
+### 7a. __App User__ wybiera opcję "Abort"
 
 ##### _\<\<invokes\>\>_ UC3 Abort CT

--- a/test_scenarios/UC4_Activate Computation Task.md
+++ b/test_scenarios/UC4_Activate Computation Task.md
@@ -1,0 +1,20 @@
+# Test Scenario
+
+## UC4 Activate CT
+
+### Scenariusz główny
+
+##### 1. __App User__ wybiera opcję wyświetlenia zdefiniowanych CT
+##### 2. System wyświetla listę zdefiniowanych CT
+##### 3. __App User__ wybiera opcję "Activate" przy zdefiniowanym CT
+##### 4. System wyświetla informację o poprawnym uruchomieniu CT
+##### 5. __App User__ wybiera opcję "OK"
+ 
+### 4a. CT miał niepoprawnie zdefiniowany logger.
+
+##### 4a1. System wyświetla otrzeżenie o niemożliwości skomunikowania się z loggerem.
+##### GOTO 5
+
+### 5a. App User wybiera opcję "Abort"
+
+##### _\<\<invokes\>\>_ UC3 Abort CT

--- a/test_scenarios/UC4_Activate Computation Task.md
+++ b/test_scenarios/UC4_Activate Computation Task.md
@@ -7,7 +7,7 @@
 ##### 1. __App User__ wybiera opcję wyświetlenia zdefiniowanych CT
 ##### 2. System wyświetla listę zdefiniowanych CT
 ##### 3. __App User__ wybiera opcję "Activate" przy zdefiniowanym CT
-##### 4. System wyśietla dane wejściowe CT.
+##### 4. System wyświetla dane wejściowe CT.
 ##### 5. __App User__ wybiera opcję "OK"
 ##### 6. System wyświetla informację o poprawnym uruchomieniu CT
 ##### 7. __App User__ wybiera opcję "OK"

--- a/test_scenarios/UC6_Create CT.md
+++ b/test_scenarios/UC6_Create CT.md
@@ -13,9 +13,13 @@
 ##### 7. __App User__ wypełnia formularz tworzenia CT
 ##### 8. __App User__ wybiera opcję "Create"
 ##### 9. System wyświetla informację o poprawnie utworzonym CT
-##### 10. __App User__ wybiera opcję "Zakończ"
+##### 10. __App User__ wybiera opcję "OK"
 ##### 11. System wyświetla listę CT 
 
-### 8a. __Użytkownik__ podał niepoprawne dane loggera.
+### 9a. __Użytkownik__ podał niepoprawne dane loggera.
 
-##### 7a1. GOTO 8 
+##### 9a1. GOTO 10 _(bez obsługi teraz, do wykorzystania później)_
+
+### 11a. __App User__ wybiera opcję "Activate"
+
+##### 11a1. _\<\<invokes\>\>_ UC4 Activate Computation Task 

--- a/test_scenarios/UC6_Create CT.md
+++ b/test_scenarios/UC6_Create CT.md
@@ -1,0 +1,21 @@
+# Test Scenario
+
+## UC6 Create CT
+
+### Główny
+
+##### 1. __App User__ wybiera opcję utworzenia CT
+##### 2. System wyświetla listę aplikacji
+##### 3. __App User__ wybiera aplikację z listy
+##### 4. System wyświetla szczegóły aplikacji
+##### 5. __App User__ wybiera opcję "Create CT"
+##### 6. System wyświetla formularz tworzenia CT
+##### 7. __App User__ wypełnia formularz tworzenia CT
+##### 8. __App User__ wybiera opcję "Create"
+##### 9. System wyświetla informację o poprawnie utworzonym CT
+##### 10. __App User__ wybiera opcję "Zakończ"
+##### 11. System wyświetla listę CT 
+
+### 8a. __Użytkownik__ podał niepoprawne dane loggera.
+
+##### 7a1. GOTO 8 

--- a/test_scenarios/UC7_create_new_CN.md
+++ b/test_scenarios/UC7_create_new_CN.md
@@ -1,0 +1,19 @@
+# Test scenario
+
+## UC7 Create new CN
+
+### Główny
+
+##### 1. __Supplier__ uruchamia klienta systemu na maszynie
+##### 2. __Supplier__ wybiera opcję dodania nowego CN
+##### 3. System wyświetla formularz dodania nowego CN
+##### 4. __Supplier__ wypełnia formularz 
+##### 5. __Supplier__ naciska przycisk "Akceptuj"
+##### 6. System wyświetla komunikat o pomyślnym dodaniu nowego CN
+##### 7. __Supplier__ wybiera opcję "Zakończ"
+##### 8. _\<\<invokes\>\>_ UC8 Show owned CN list
+
+### 5a. __Supplier__ podał dane nieistniejącej maszyny.
+
+##### 5a1. System wyświetla komunikat o braku połączenia
+##### 5a2. ___GOTO 7___

--- a/test_scenarios/UC8_Show owned CN list.md
+++ b/test_scenarios/UC8_Show owned CN list.md
@@ -1,0 +1,8 @@
+# Test Scenario
+
+## UC8 Show owned CN list
+
+### Główny 
+
+##### 1. __App User__ wybiera opcję wyświetlenia listy posiadanych CN'ów.
+##### 2. System wyświetla listę posiadanych CN'ów użytkownika (ich nazwę, parametry i status obliczania)

--- a/test_scenarios/UC9_signal_own_status.md
+++ b/test_scenarios/UC9_signal_own_status.md
@@ -1,0 +1,5 @@
+# Test Scenario
+
+## UC9 Signal own status
+
+\-


### PR DESCRIPTION
Resolves #11 

Nie wiem czy i jaki dodać scenariusz do [UC9 Signal owned status](https://plan-b-po.github.io/docs/scenarios/UC9_signal_own_status). 

Planowana kolejność wykonywania scenariuszy:

- [UC8](https://github.com/Plan-B-PO/docs/blob/test/test_scenarios/UC8_Show%20owned%20CN%20list.md)
- [UC7](https://github.com/Plan-B-PO/docs/blob/test/test_scenarios/UC7_create_new_CN.md)
- [UC6](https://github.com/Plan-B-PO/docs/blob/test/test_scenarios/UC6_Create%20CT.md)
- [UC4](https://github.com/Plan-B-PO/docs/blob/test/test_scenarios/UC4_Activate%20Computation%20Task.md)
- [~UC9~](https://github.com/Plan-B-PO/docs/blob/test/test_scenarios/UC9_signal_own_status.md)
- [UC3](https://github.com/Plan-B-PO/docs/blob/test/test_scenarios/UC3_Abort%20CT.md)